### PR TITLE
Debian/Ubuntu: use 'ssh' as systemd unit name (not 'sshd')

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,8 @@
 ---
 openssh_dest: '/etc/ssh'
-openssh_service: 'sshd'
+# На Debian/Ubuntu systemd-unit называется ssh.service, не sshd.service.
+# Алиас Alias=sshd.service в [Install] секции даёт `systemctl enable sshd`
+# работать только ПОСЛЕ того как unit был enabled первый раз. На свежей
+# VM-ке этот alias ещё не зарегистрирован — `systemctl enable sshd` падает
+# с "Could not find the requested service sshd". Используем 'ssh' напрямую.
+openssh_service: 'ssh'


### PR DESCRIPTION
## Summary

- Fix \`vars/Debian.yml\`: \`openssh_service: 'sshd' → 'ssh'\`.

## Why

On Debian/Ubuntu the systemd unit is \`ssh.service\`. The \`sshd\` name is an alias declared via \`Alias=sshd.service\` in the \`[Install]\` section of \`ssh.service\` — but systemd only registers this alias **after** the unit is enabled for the first time.

On a freshly-provisioned VM the alias doesn't exist yet, so \`systemctl enable sshd\` fails with:

\`\`\`
Could not find the requested service sshd: host
\`\`\`

On already-managed hosts (mx.napaster.ru, mx.mail-ok.ru) the role appeared to work fine because \`ssh\` was enabled long ago and the alias was already populated.

\`ansible_os_family\` returns \`Debian\` for both Debian and Ubuntu, so this single var file covers both — no separate Ubuntu.yml needed.

## Test plan

- [ ] Run on freshly-provisioned Ubuntu 24.04 — \`Enable openssh daemon service\` task passes.
- [ ] Re-run on mx.napaster.ru / mx.mail-ok.ru — idempotent, no service restart.
- [ ] Confirm \`systemctl status ssh\` reports active+enabled.